### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,8 +1,8 @@
-[![Latest Version](https://pypip.in/version/itemizer/badge.svg)](https://pypi.python.org/pypi/itemizer/)
-[![Downloads](https://pypip.in/download/itemizer/badge.svg)](https://pypi.python.org/pypi/itemizer/)
-[![Supported Python versions](https://pypip.in/py_versions/itemizer/badge.svg)](https://pypi.python.org/pypi/itemizer/)
-[![Development Status](https://pypip.in/status/itemizer/badge.svg)](https://pypi.python.org/pypi/itemizer/)
-[![License](https://pypip.in/license/itemizer/badge.svg)](https://pypi.python.org/pypi/itemizer/)
+[![Latest Version](https://img.shields.io/pypi/v/itemizer.svg)](https://pypi.python.org/pypi/itemizer/)
+[![Downloads](https://img.shields.io/pypi/dm/itemizer.svg)](https://pypi.python.org/pypi/itemizer/)
+[![Supported Python versions](https://img.shields.io/pypi/pyversions/itemizer.svg)](https://pypi.python.org/pypi/itemizer/)
+[![Development Status](https://img.shields.io/pypi/status/itemizer.svg)](https://pypi.python.org/pypi/itemizer/)
+[![License](https://img.shields.io/pypi/l/itemizer.svg)](https://pypi.python.org/pypi/itemizer/)
 
 
 itemizer


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20itemizer))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `itemizer`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.